### PR TITLE
Switch to color logo from mono in the top nav bar

### DIFF
--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -84,7 +84,7 @@ export function Root(props: NavProps) {
           </Link>
           <div className="omrs-type-title-4">
             <svg role="img" width="10rem">
-              <use xlinkHref="#omrs-logo-partial-mono"></use>
+              <use xlinkHref="#omrs-logo-partial-color"></use>
             </svg>
           </div>
           <div>


### PR DESCRIPTION
The logo in the nav bar looks like a background instead of logo. So switched to color logo instead of mono.

Before Change:
![image](https://user-images.githubusercontent.com/38713281/81927573-7cbb3a00-9601-11ea-8c15-c2a70305dfb3.png)

After Change:
![image](https://user-images.githubusercontent.com/38713281/81927459-4d0c3200-9601-11ea-853e-f74445b18f98.png)
