### PR TITLE
MF-215  Navigation Bar - Fix Logout menu is not clearly visible issue

### DIFF
--- a/src/root.styles.css
+++ b/src/root.styles.css
@@ -24,7 +24,7 @@
   justify-content: flex-end;
   width: 100%;
   right: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 .userMenuCard {


### PR DESCRIPTION
MF-215  Navigation Bar - Fix Logout menu is not clearly visible issue

**Steps:**
1. Login to https://openmrs-spa.org/openmrs/spa
2. Search for any patient
3. Click on the patient card
4. Patient charts will be opened
5. Click the expand icon in the nav bar.
6. Menu is not clearly visible, refer screenshots below.


Before Fix:
![image](https://user-images.githubusercontent.com/38713281/82029941-5525a980-96b5-11ea-8fed-641e153f9dc0.png)

After Fix:
![image](https://user-images.githubusercontent.com/38713281/82029967-653d8900-96b5-11ea-8fe1-9c8a16bbaa67.png)

