### PR TITLE
Make left nav slot sensitive to activePage

### DIFF
--- a/src/components/nav-header-panels/side-menu-panel.component.tsx
+++ b/src/components/nav-header-panels/side-menu-panel.component.tsx
@@ -1,14 +1,26 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { SideNav, SideNavProps } from "carbon-components-react";
 import { ExtensionSlot } from "@openmrs/esm-react-utils";
+import { getAppState } from "@openmrs/esm-api";
 
 interface SideMenuPanelProps extends SideNavProps {}
 
 const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded }) => {
+  const [activePage, setActivePage] = useState();
+
+  useEffect(() => {
+    setActivePage(getAppState().getState().activePage);
+    return getAppState().subscribe(v => {
+      setActivePage(v.activePage);
+    });
+  }, []);
+
   return (
     expanded && (
       <SideNav expanded aria-label="Menu">
-        <ExtensionSlot extensionSlotName="nav-menu" />
+        {activePage && (
+          <ExtensionSlot extensionSlotName={`nav-menu-${activePage}`} />
+        )}
       </SideNav>
     )
   );


### PR DESCRIPTION
Depends on https://github.com/openmrs/openmrs-esm-core/pull/45

Screenshots taken after doing

```
attach("nav-menu-home", "active-visits-link");
attach("nav-menu-patient-chart", "reports-link");
```

![home-ext](https://user-images.githubusercontent.com/1031876/100683895-1c39e300-332e-11eb-84fd-e972e3c5afe5.png)
![pt-chart-ext](https://user-images.githubusercontent.com/1031876/100683897-1e9c3d00-332e-11eb-8139-e1920d42fc68.png)
