### PR TITLE
MF-528: Fixup for styling of HeaderGLobalAction buttons on the navigation bar

### DIFF
--- a/src/components/navbar/navbar.component.css
+++ b/src/components/navbar/navbar.component.css
@@ -1,0 +1,3 @@
+.headerGlobalActionSlot > div{
+    display: flex;
+}

--- a/src/components/navbar/navbar.component.tsx
+++ b/src/components/navbar/navbar.component.tsx
@@ -16,6 +16,7 @@ import {
 } from "carbon-components-react/es/components/UIShell";
 import { LoggedInUser, UserSession } from "../../types";
 import AppMenuPanel from "../navbar-header-panels/app-menu-panel.component";
+import styles from "./navbar.component.css";
 
 const HeaderLink: any = HeaderName;
 
@@ -87,7 +88,9 @@ const Navbar: React.FC<NavbarProps> = ({
                 <Logo />
               </HeaderLink>
               <HeaderGlobalBar>
-                <ExtensionSlot extensionSlotName="top-nav-actions-slot" />
+                <div className={styles.headerGlobalActionSlot}>
+                  <ExtensionSlot extensionSlotName="top-nav-actions-slot" />
+                </div>
                 <HeaderGlobalAction
                   aria-label="Users"
                   aria-labelledby="Users Avatar Icon"


### PR DESCRIPTION
**What does this PR do?**

This PR is a solution to MF-528. After addition of the `Implementor tools` button on the navigation bar, the styling of the navigation bar was disturbed due to wrapping of the HeaderGlobalAction Buttons with a div tag. The before and after pics are added below.
![Screenshot from 2021-04-02 11-22-25](https://user-images.githubusercontent.com/51502471/113395882-3527d300-93b8-11eb-8442-5acff705337e.png)
![Screenshot from 2021-04-02 13-34-27](https://user-images.githubusercontent.com/51502471/113395888-378a2d00-93b8-11eb-845f-2054fcafa621.png)

