### PR TITLE
MF-434 :  Make logo spot on navbar configurable

### DIFF
--- a/src/components/logo/logo.component.test.tsx
+++ b/src/components/logo/logo.component.test.tsx
@@ -1,0 +1,47 @@
+import { useConfig } from "@openmrs/esm-framework";
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import Logo from "./logo.component";
+
+const mockUseConfig = useConfig as jest.Mock;
+
+jest.mock("@openmrs/esm-framework", () => ({
+  useConfig: jest.fn()
+}));
+
+describe("<Logo/>", () => {
+  afterEach(cleanup);
+
+  it("should display OpenMRS logo", () => {
+    const mockConfig = { logo: { src: null, alt: null, name: null } };
+    mockUseConfig.mockReturnValue(mockConfig);
+    render(<Logo />);
+    const logo = screen.getByRole("img");
+    expect(logo).toBeInTheDocument();
+    expect(logo).toContainHTML("svg");
+  });
+
+  it("should display name", () => {
+    const mockConfig = {
+      logo: { src: null, alt: null, name: "Some weird EMR" }
+    };
+    mockUseConfig.mockReturnValue(mockConfig);
+    render(<Logo />);
+    expect(screen.getByText(/Some weird EMR/i)).toBeInTheDocument();
+  });
+
+  it("should display image logo", () => {
+    const mockConfig = {
+      logo: {
+        src: "https://someimage.png",
+        alt: "alternative text",
+        name: null
+      }
+    };
+    mockUseConfig.mockReturnValue(mockConfig);
+    render(<Logo />);
+    const logo = screen.getByRole("img");
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute("alt");
+  });
+});

--- a/src/components/logo/logo.component.tsx
+++ b/src/components/logo/logo.component.tsx
@@ -1,24 +1,16 @@
 import * as React from "react";
+import { useConfig } from "@openmrs/esm-framework";
 
-interface LogoProps {
-  src?: string;
-  alt?: string;
-  width?: number;
-  height?: number;
-}
-
-const Logo: React.FC<LogoProps> = ({
-  width = "110",
-  height = "40",
-  src,
-  alt
-}) => {
+const Logo: React.FC = () => {
+  const { logo } = useConfig();
   return (
     <>
-      {src ? (
-        <img src={src} alt={alt} width={width} height={height} />
+      {logo?.src ? (
+        <img src={logo.src} alt={logo.alt} width={110} height={40} />
+      ) : logo?.name ? (
+        logo.name
       ) : (
-        <svg role="img" width={width} height={height}>
+        <svg role="img" width={110} height={40}>
           <use xlinkHref="#omrs-logo-partial-grey"></use>
         </svg>
       )}

--- a/src/components/logo/logo.component.tsx
+++ b/src/components/logo/logo.component.tsx
@@ -1,10 +1,28 @@
 import * as React from "react";
 
-const Logo = ({ width = "110", height = "40" }) => {
+interface LogoProps {
+  src?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+const Logo: React.FC<LogoProps> = ({
+  width = "110",
+  height = "40",
+  src,
+  alt
+}) => {
   return (
-    <svg role="img" width={width} height={height}>
-      <use xlinkHref="#omrs-logo-partial-grey"></use>
-    </svg>
+    <>
+      {src ? (
+        <img src={src} alt={alt} width={width} height={height} />
+      ) : (
+        <svg role="img" width={width} height={height}>
+          <use xlinkHref="#omrs-logo-partial-grey"></use>
+        </svg>
+      )}
+    </>
   );
 };
 

--- a/src/components/navbar/navbar.component.tsx
+++ b/src/components/navbar/navbar.component.tsx
@@ -4,7 +4,12 @@ import UserMenuPanel from "../navbar-header-panels/user-menu-panel.component";
 import SideMenuPanel from "../navbar-header-panels/side-menu-panel.component";
 import Logo from "../logo/logo.component";
 import { isDesktop } from "../../utils";
-import { useLayoutType, navigate, ExtensionSlot } from "@openmrs/esm-framework";
+import {
+  useLayoutType,
+  navigate,
+  ExtensionSlot,
+  useConfig
+} from "@openmrs/esm-framework";
 import Switcher20 from "@carbon/icons-react/lib/switcher/20";
 import Close20 from "@carbon/icons-react/lib/close/20";
 import {
@@ -34,6 +39,7 @@ const Navbar: React.FC<NavbarProps> = ({
   allowedLocales,
   session
 }) => {
+  const config = useConfig();
   const layout = useLayoutType();
   const headerRef = React.useRef(null);
   const [activeHeaderPanel, setActiveHeaderPanel] = React.useState<string>(
@@ -88,7 +94,11 @@ const Navbar: React.FC<NavbarProps> = ({
                   hidePanel();
                 }}
               >
-                <Logo />
+                {config.logo.name ? (
+                  config.logo.name
+                ) : (
+                  <Logo src={config.logo?.src} alt={config.logo?.alt} />
+                )}
               </HeaderLink>
               <HeaderGlobalBar>
                 <ExtensionSlot

--- a/src/components/navbar/navbar.component.tsx
+++ b/src/components/navbar/navbar.component.tsx
@@ -4,12 +4,7 @@ import UserMenuPanel from "../navbar-header-panels/user-menu-panel.component";
 import SideMenuPanel from "../navbar-header-panels/side-menu-panel.component";
 import Logo from "../logo/logo.component";
 import { isDesktop } from "../../utils";
-import {
-  useLayoutType,
-  navigate,
-  ExtensionSlot,
-  useConfig
-} from "@openmrs/esm-framework";
+import { useLayoutType, navigate, ExtensionSlot } from "@openmrs/esm-framework";
 import Switcher20 from "@carbon/icons-react/lib/switcher/20";
 import Close20 from "@carbon/icons-react/lib/close/20";
 import {
@@ -39,7 +34,6 @@ const Navbar: React.FC<NavbarProps> = ({
   allowedLocales,
   session
 }) => {
-  const config = useConfig();
   const layout = useLayoutType();
   const headerRef = React.useRef(null);
   const [activeHeaderPanel, setActiveHeaderPanel] = React.useState<string>(
@@ -94,11 +88,7 @@ const Navbar: React.FC<NavbarProps> = ({
                   hidePanel();
                 }}
               >
-                {config.logo.name ? (
-                  config.logo.name
-                ) : (
-                  <Logo src={config.logo?.src} alt={config.logo?.alt} />
-                )}
+                <Logo />
               </HeaderLink>
               <HeaderGlobalBar>
                 <ExtensionSlot

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,0 +1,22 @@
+import { Type } from "@openmrs/esm-framework";
+
+export const configSchema = {
+  logo: {
+    src: {
+      _type: Type.String,
+      _default: null,
+      _description:
+        "A path or URL to an image. Defaults to the OpenMRS SVG sprite."
+    },
+    alt: {
+      _type: Type.String,
+      _default: "Logo",
+      _description: "Alt text, shown on hover"
+    },
+    name: {
+      _type: Type.String,
+      _default: null,
+      _description: "The organization name displayed when image is absent"
+    }
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { defineConfigSchema, getAsyncLifecycle } from "@openmrs/esm-framework";
+import { configSchema } from "./config-schema";
 
 const backendDependencies = { "webservices.rest": "^2.2.0" };
 
@@ -17,7 +18,7 @@ function setupOpenMRS() {
     moduleName
   };
 
-  defineConfigSchema(moduleName, {});
+  defineConfigSchema(moduleName, configSchema);
 
   return {
     lifecycle: getAsyncLifecycle(() => import("./root.component"), options),

--- a/src/root.component.test.tsx
+++ b/src/root.component.test.tsx
@@ -57,6 +57,7 @@ describe(`<Root />`, () => {
     expect(
       screen.getByRole("banner", { name: /OpenMRS/i })
     ).toBeInTheDocument();
+    expect(screen.getByText(/Mock EMR/i)).toBeInTheDocument();
   });
 
   it("should open user-menu panel", async () => {

--- a/src/root.component.test.tsx
+++ b/src/root.component.test.tsx
@@ -7,12 +7,17 @@ import {
 } from "@testing-library/react";
 import { of } from "rxjs";
 import { isDesktop } from "./utils";
-import { getCurrentUser, openmrsObservableFetch } from "@openmrs/esm-framework";
+import {
+  getCurrentUser,
+  openmrsObservableFetch,
+  useConfig
+} from "@openmrs/esm-framework";
 import Root from "./root.component";
 import { mockUser } from "../__mocks__/mock-user";
 
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockOpenmrsObservableFetch = openmrsObservableFetch as jest.Mock;
+const mockUseConfig = useConfig as jest.Mock;
 
 jest.mock("@openmrs/esm-framework", () => ({
   openmrsFetch: jest.fn().mockResolvedValue({}),
@@ -24,7 +29,8 @@ jest.mock("@openmrs/esm-framework", () => ({
   ExtensionSlot: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
-  useLayoutType: jest.fn(() => "tablet")
+  useLayoutType: jest.fn(() => "tablet"),
+  useConfig: jest.fn()
 }));
 
 jest.mock("./utils", () => ({ isDesktop: jest.fn(() => false) }));
@@ -35,6 +41,9 @@ describe(`<Root />`, () => {
     mockOpenmrsObservableFetch.mockImplementation(() =>
       of({ data: { sessionLocation: { display: "Unknown Location" } } })
     );
+    mockUseConfig.mockReturnValue({
+      logo: { src: null, alt: null, name: "Mock EMR" }
+    });
     render(<Root />);
   });
 


### PR DESCRIPTION
### What does this PR do?


1. Make the primary navigation navbar icon configurable.
### Screenshots

![screencast 2021-04-07 11-00-44](https://user-images.githubusercontent.com/28008754/113833271-22374900-9792-11eb-96ee-51c295804abf.gif)

